### PR TITLE
fix pillow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ torch==1.2
 torchvision==0.4
 python-json-logger==0.1.10
 tb-nightly==1.15.0a20190903
+Pillow==6.1.0
+


### PR DESCRIPTION
## What is this PR for?

with Pillow==6.0.0, some jpeg images are not read properly according to [this issue](https://github.com/python-pillow/Pillow/issues/3769).
So update and fix Pillow version to 6.1.0.

## This PR includes

- fix Pillow version in requirements.txt

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

- executed in ABEJA Platform and checked if it completes.

