### PR TITLE
Bugfix/dateset item without bounding box

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -129,6 +129,8 @@ class ABEJAPlatformDataset(data.Dataset):
         # 2. build list of annotation
         anno_list = []
         if not dataset_item.attributes['detection']:
+            # NOTE: add annotation as background ( no object )
+            # label_id: -1 will be incremented and used for background
             dataset_item.attributes['detection'] = [
                 {
                     'label_id': -1,
@@ -152,8 +154,9 @@ class ABEJAPlatformDataset(data.Dataset):
                 label_id
             ])
 
-        # 3. perform preprocess
         anno_list = np.array(anno_list)
+
+        # 3. perform preprocess
         img, boxes, labels = self.transform(
             img, self.phase, anno_list[:, :4], anno_list[:, 4])
 

--- a/dataset.py
+++ b/dataset.py
@@ -128,6 +128,18 @@ class ABEJAPlatformDataset(data.Dataset):
 
         # 2. build list of annotation
         anno_list = []
+        if not dataset_item.attributes['detection']:
+            dataset_item.attributes['detection'] = [
+                {
+                    'label_id': -1,
+                    'rect': {
+                        'xmin': width,
+                        'ymin': height,
+                        'xmax': width,
+                        'ymax': height,
+                    }
+                }
+            ]
         for detection in dataset_item.attributes['detection']:
             label_id = detection['label_id']
             rect = detection['rect']
@@ -141,12 +153,9 @@ class ABEJAPlatformDataset(data.Dataset):
             ])
 
         # 3. perform preprocess
-        if anno_list:
-            anno_list = np.array(anno_list)
-            img, boxes, labels = self.transform(
-                img, self.phase, anno_list[:, :4], anno_list[:, 4])
-        else:
-            img, boxes, labels = self.transform(img, self.phase, np.empty(0), np.empty(0))
+        anno_list = np.array(anno_list)
+        img, boxes, labels = self.transform(
+            img, self.phase, anno_list[:, :4], anno_list[:, 4])
 
         # change channel color order from BGR to RGB
         # and convert order from (h, w, c) to (c, h, w)

--- a/dataset.py
+++ b/dataset.py
@@ -140,11 +140,13 @@ class ABEJAPlatformDataset(data.Dataset):
                 label_id
             ])
 
-        anno_list = np.array(anno_list)
-
         # 3. perform preprocess
-        img, boxes, labels = self.transform(
-            img, self.phase, anno_list[:, :4], anno_list[:, 4])
+        if anno_list:
+            anno_list = np.array(anno_list)
+            img, boxes, labels = self.transform(
+                img, self.phase, anno_list[:, :4], anno_list[:, 4])
+        else:
+            img, boxes, labels = self.transform(img, self.phase, np.empty(0), np.empty(0))
 
         # change channel color order from BGR to RGB
         # and convert order from (h, w, c) to (c, h, w)

--- a/predict.py
+++ b/predict.py
@@ -81,7 +81,7 @@ def handler(request, context):
     content = contents[0].read()
     f = io.BytesIO(content)
     pil_img = Image.open(f)
-    pil_img = np.asarray(pil_img).astype(np.float32)
+    pil_img = np.asarray(pil_img.convert('RGB')).astype(np.float32)
     height, width, _channels = pil_img.shape
     print(f'image shape, (height, width, channels) : ({height}, {width}, {_channels})')
 

--- a/predict.py
+++ b/predict.py
@@ -83,17 +83,7 @@ def handler(request, context):
     pil_img = Image.open(f)
     pil_img = np.asarray(pil_img).astype(np.float32)
     height, width, _channels = pil_img.shape
-
-    # TODO: currently image smaller than IMG_SIZE will not be handled properly.
-    if height < Parameters.IMG_SIZE or width < Parameters.IMG_SIZE:
-        return {
-            'status_code': http.HTTPStatus.BAD_REQUEST,
-            'content_type': 'application/json',
-            'content': {
-                'error': http.HTTPStatus.BAD_REQUEST[1],
-                'description': f'height and width should be greater than {Parameters.IMG_SIZE}'
-            }
-        }
+    print(f'image shape, (height, width, channels) : ({height}, {width}, {_channels})')
 
     # the dataset's mean rgb values,
     transform = DataTransform(

--- a/utils/data_augumentation.py
+++ b/utils/data_augumentation.py
@@ -86,7 +86,7 @@ class SubtractMeans(object):
 
 class ToAbsoluteCoords(object):
     def __call__(self, image, boxes=None, labels=None):
-        if boxes is not None:
+        if len(boxes) > 0:
             height, width, channels = image.shape
             boxes[:, 0] *= width
             boxes[:, 2] *= width
@@ -98,7 +98,7 @@ class ToAbsoluteCoords(object):
 
 class ToPercentCoords(object):
     def __call__(self, image, boxes=None, labels=None):
-        if boxes is not None:
+        if len(boxes) > 0:
             height, width, channels = image.shape
             boxes[:, 0] /= width
             boxes[:, 2] /= width
@@ -269,7 +269,7 @@ class RandomSampleCrop(object):
                 # convert to integer rect x1,y1,x2,y2
                 rect = np.array([int(left), int(top), int(left+w), int(top+h)])
 
-                if boxes is None:
+                if len(boxes) == 0:
                     return current_image, boxes, labels
 
                 # calculate IoU (jaccard overlap) b/t the cropped and gt boxes
@@ -340,7 +340,7 @@ class Expand(object):
                      int(left):int(left + width)] = image
         image = expand_image
 
-        if boxes is not None:
+        if len(boxes) > 0:
             boxes = boxes.copy()
             boxes[:, :2] += (int(left), int(top))
             boxes[:, 2:] += (int(left), int(top))
@@ -351,6 +351,8 @@ class Expand(object):
 class RandomMirror(object):
     def __call__(self, image, boxes, classes):
         _, width, _ = image.shape
+        if len(boxes) < 1:
+            return image, boxes, classes
         if random.randint(2):
             image = image[:, ::-1]
             boxes = boxes.copy()

--- a/utils/data_augumentation.py
+++ b/utils/data_augumentation.py
@@ -85,25 +85,23 @@ class SubtractMeans(object):
 
 
 class ToAbsoluteCoords(object):
-    def __call__(self, image, boxes=None, labels=None):
-        if len(boxes) > 0:
-            height, width, channels = image.shape
-            boxes[:, 0] *= width
-            boxes[:, 2] *= width
-            boxes[:, 1] *= height
-            boxes[:, 3] *= height
+    def __call__(self, image, boxes, labels):
+        height, width, channels = image.shape
+        boxes[:, 0] *= width
+        boxes[:, 2] *= width
+        boxes[:, 1] *= height
+        boxes[:, 3] *= height
 
         return image, boxes, labels
 
 
 class ToPercentCoords(object):
-    def __call__(self, image, boxes=None, labels=None):
-        if len(boxes) > 0:
-            height, width, channels = image.shape
-            boxes[:, 0] /= width
-            boxes[:, 2] /= width
-            boxes[:, 1] /= height
-            boxes[:, 3] /= height
+    def __call__(self, image, boxes, labels):
+        height, width, channels = image.shape
+        boxes[:, 0] /= width
+        boxes[:, 2] /= width
+        boxes[:, 1] /= height
+        boxes[:, 3] /= height
 
         return image, boxes, labels
 
@@ -238,7 +236,7 @@ class RandomSampleCrop(object):
             (None, None),
         )
 
-    def __call__(self, image, boxes=None, labels=None):
+    def __call__(self, image, boxes, labels):
         height, width, _ = image.shape
         while True:
             # randomly choose a mode
@@ -268,9 +266,6 @@ class RandomSampleCrop(object):
 
                 # convert to integer rect x1,y1,x2,y2
                 rect = np.array([int(left), int(top), int(left+w), int(top+h)])
-
-                if len(boxes) == 0:
-                    return current_image, boxes, labels
 
                 # calculate IoU (jaccard overlap) b/t the cropped and gt boxes
                 overlap = jaccard_numpy(boxes, rect)
@@ -323,7 +318,7 @@ class Expand(object):
     def __init__(self, mean):
         self.mean = mean
 
-    def __call__(self, image, boxes=None, labels=None):
+    def __call__(self, image, boxes, labels):
         if random.randint(2):
             return image, boxes, labels
 
@@ -340,10 +335,9 @@ class Expand(object):
                      int(left):int(left + width)] = image
         image = expand_image
 
-        if len(boxes) > 0:
-            boxes = boxes.copy()
-            boxes[:, :2] += (int(left), int(top))
-            boxes[:, 2:] += (int(left), int(top))
+        boxes = boxes.copy()
+        boxes[:, :2] += (int(left), int(top))
+        boxes[:, 2:] += (int(left), int(top))
 
         return image, boxes, labels
 
@@ -351,8 +345,6 @@ class Expand(object):
 class RandomMirror(object):
     def __call__(self, image, boxes, classes):
         _, width, _ = image.shape
-        if len(boxes) < 1:
-            return image, boxes, classes
         if random.randint(2):
             image = image[:, ::-1]
             boxes = boxes.copy()

--- a/utils/data_augumentation.py
+++ b/utils/data_augumentation.py
@@ -86,22 +86,24 @@ class SubtractMeans(object):
 
 class ToAbsoluteCoords(object):
     def __call__(self, image, boxes=None, labels=None):
-        height, width, channels = image.shape
-        boxes[:, 0] *= width
-        boxes[:, 2] *= width
-        boxes[:, 1] *= height
-        boxes[:, 3] *= height
+        if boxes is not None:
+            height, width, channels = image.shape
+            boxes[:, 0] *= width
+            boxes[:, 2] *= width
+            boxes[:, 1] *= height
+            boxes[:, 3] *= height
 
         return image, boxes, labels
 
 
 class ToPercentCoords(object):
     def __call__(self, image, boxes=None, labels=None):
-        height, width, channels = image.shape
-        boxes[:, 0] /= width
-        boxes[:, 2] /= width
-        boxes[:, 1] /= height
-        boxes[:, 3] /= height
+        if boxes is not None:
+            height, width, channels = image.shape
+            boxes[:, 0] /= width
+            boxes[:, 2] /= width
+            boxes[:, 1] /= height
+            boxes[:, 3] /= height
 
         return image, boxes, labels
 
@@ -267,6 +269,9 @@ class RandomSampleCrop(object):
                 # convert to integer rect x1,y1,x2,y2
                 rect = np.array([int(left), int(top), int(left+w), int(top+h)])
 
+                if boxes is None:
+                    return current_image, boxes, labels
+
                 # calculate IoU (jaccard overlap) b/t the cropped and gt boxes
                 overlap = jaccard_numpy(boxes, rect)
 
@@ -318,7 +323,7 @@ class Expand(object):
     def __init__(self, mean):
         self.mean = mean
 
-    def __call__(self, image, boxes, labels):
+    def __call__(self, image, boxes=None, labels=None):
         if random.randint(2):
             return image, boxes, labels
 
@@ -335,9 +340,10 @@ class Expand(object):
                      int(left):int(left + width)] = image
         image = expand_image
 
-        boxes = boxes.copy()
-        boxes[:, :2] += (int(left), int(top))
-        boxes[:, 2:] += (int(left), int(top))
+        if boxes is not None:
+            boxes = boxes.copy()
+            boxes[:, :2] += (int(left), int(top))
+            boxes[:, 2:] += (int(left), int(top))
 
         return image, boxes, labels
 


### PR DESCRIPTION
## What is this PR for?

- to support dateset item without bounding boxes and labels
- fix bug of error response 

## This PR includes

## What type of PR is it?

Bugfix

## What is the issue?

to support dataset_item with empty `detection` property.

## How should this be tested?

trained with PascalVOC data without `train` and `tvmonitor` annotations.

<img width="676" alt="スクリーンショット 2019-09-25 18 38 36" src="https://user-images.githubusercontent.com/17197355/65589380-e5e33400-dfc3-11e9-9c86-b259a96d0886.png">
